### PR TITLE
Strip quotes from configmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ local.tfvars
 *.hcl
 *.tfstate
 test
+.vscode

--- a/configmap.tf
+++ b/configmap.tf
@@ -7,58 +7,60 @@ resource "kubernetes_manifest" "agent" {
       namespace = var.namespace
     }
     data = {
-      "agent.yaml" = yamlencode({
-        server = {
-          log_level  = "info"
-          log_format = "json"
-        }
-        traces = {
-          configs = [{
-            name = "default"
-            attributes = {
-              actions = [{
-                key    = "env"
-                action = "upsert"
-                value  = var.environment
-                }, {
-                key    = "project"
-                action = "upsert"
-                value  = var.project
-              }]
-            }
-            batch = {
-              send_batch_size = 1000
-              timeout         = "5s"
-            }
-            remote_write = concat([{
-              endpoint = var.tempo_endpoint
-              basic_auth = {
-                username = var.tempo_username
-                password_file : "/run/secrets/grafana/${var.tempo_api_key_secret.key}"
+      "agent.yaml" = replace(
+        yamlencode({
+          server = {
+            log_level  = "info"
+            log_format = "json"
+          }
+          traces = {
+            configs = [{
+              name = "default"
+              attributes = {
+                actions = [{
+                  key    = "env"
+                  action = "upsert"
+                  value  = var.environment
+                  }, {
+                  key    = "project"
+                  action = "upsert"
+                  value  = var.project
+                }]
               }
-              retry_on_failure = {
-                enabled : true
+              batch = {
+                send_batch_size = 1000
+                timeout         = "5s"
               }
-            }], var.additional_remote_writes)
-            receivers = {
-              otlp = {
-                protocols = {
-                  grpc = {
-                    include_metadata : true
+              remote_write = concat([{
+                endpoint = var.tempo_endpoint
+                basic_auth = {
+                  username = var.tempo_username
+                  password_file : "/run/secrets/grafana/${var.tempo_api_key_secret.key}"
+                }
+                retry_on_failure = {
+                  enabled : true
+                }
+              }], var.additional_remote_writes)
+              receivers = {
+                otlp = {
+                  protocols = {
+                    grpc = {
+                      include_metadata : true
+                    }
                   }
                 }
               }
-            }
-            automatic_logging = {
-              backend = "stdout"
-              roots : true
-              overrides = {
-                trace_id_key : "trace_id"
+              automatic_logging = {
+                backend = "stdout"
+                roots : true
+                overrides = {
+                  trace_id_key : "trace_id"
+                }
               }
-            }
-          }]
-        }
-      })
+            }]
+          }
+        }),
+      "\"", "")
     }
   }
 }


### PR DESCRIPTION
Terraform wants to update the configmap at every plan because it's created in k8s without quotes